### PR TITLE
Bug fix in Client JcrNodesWriter when node name appears more than once in the path

### DIFF
--- a/grabbit/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/grabbit/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -102,11 +102,13 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
         log.debug "Primary Type: ${primaryType}"
 
         if (primaryType == NT_FILE) {
-            def temp = nodeProto.name.split("/")
-            final String fileName = temp.last()
-            final String parentName = nodeProto.name.replaceAll("/${fileName}", "")
-            final JcrNode parentNode = JcrUtils.getOrCreateByPath(parentName, null, session)
-            JcrNode fileNode = JcrUtils.getOrAddNode(parentNode, fileName, NodeType.NT_FILE)
+            def currentNameArray = nodeProto.name.split("/")
+            //currentNameArray[-1] finds the member of the last index
+            final String currentFileName = currentNameArray[-1]
+            //The path leading up to the second to last index.  e.g /content/foo/bar of /content/foo/bar/file
+            final String immediateParentName = currentNameArray[0..-2].join("/")
+            final JcrNode parentNode = JcrUtils.getOrCreateByPath(immediateParentName, null, session)
+            JcrNode fileNode = JcrUtils.getOrAddNode(parentNode, currentFileName, NodeType.NT_FILE)
             JcrNode theNode = JcrUtils.getOrAddNode(fileNode, JCR_CONTENT, NodeType.NT_RESOURCE)
 
             //TODO : This is a workaround for the case where a chunk gets 'saved' in JCR and the last node was 'nt:file'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,12 +72,14 @@ dependencies {
         exclude module: "httpcore"
         exclude module: "httpclient-cache"
         exclude module: "httpmime"
+        exclude module: "fluent-hc"
     }
     compile "org.apache.httpcomponents:httpcore-osgi:${httpcomponents_core_version}", {
         exclude module: "httpclient-cache"
         exclude module: "httpcore"
         exclude module: "httpcore-nio"
         exclude module: "httpmime"
+        exclude module: "fluent-hc"
     }
 
     compile "org.apache.servicemix.bundles:org.apache.servicemix.bundles.protobuf-java:${servicemix_protobuf_java_version}"


### PR DESCRIPTION
Found this bug where if the current node path is like `/foo/blah/bar/foo` .. and the child `/foo` is of type `nt:file`, we were effectively adding that child to `/blah/bar` instead of `/foo/blah/bar` 

Also added a test for this case.

@jdigger @jazeren1 