### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-language: java
+language: groovy
+
+addons:
+  apt:
+    packages:
+      - protobuf-compiler
 
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ addons:
     packages:
       - protobuf-compiler
 
+#Yeah, we are going to want to cache our build dependencies so our builds aren't held up downloading for every container
+cache:
+  directories:
+    - $HOME/.gradle
+
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: groovy
 
+#The Travis team has approved protobuf 2.4.1 as a "safe" apt package.  2.4.1 is currently the only version available.  See full whitelist here : https://github.com/travis-ci/apt-package-whitelist
 addons:
   apt:
     packages:
@@ -18,5 +19,12 @@ jdk:
 # Allow running on a container instead of a traditional VM
 sudo: false
 
-# show the logging of tests, and there's no need to run the daemon on a single-use container
-script: ./gradlew check -iS --no-daemon
+#There is currently an issue in Gradle where a forked JVM will ignore any no-daemon flag (--no-daemon, org.gradle.daemon) for the forked process if jvm args are supplied. 
+#We remove them to get around this
+env:
+  - GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=''"
+
+#Travis will mark a build as a failed if the script/install process exits(1).  Since the normal Gradle wrapper exits 0 even if the test runner reports failures, we have to wrap the wrapper.  
+#We want to replace the default install task.  Travis automatically adds "./gradlew assemble" if it detects a gradle project
+install: ./travis-gradlew assemble
+script: ./travis-gradlew check

--- a/travis-gradlew
+++ b/travis-gradlew
@@ -1,0 +1,9 @@
+#!/bin/bash
+#This wrapper's primary purpose is to serve TravisCI by wrapping the "regular" Gradle Wrapper; detect test, or build failure; and close the process with the appropriate exit code
+#The "regular" Gradle wrapper in valid use operation always exits with 0, regardless of test runner failure, or compiler daemon failure
+exec 3<&1
+stderr=$( ./gradlew $@ -i  2>&1 >&3 )  
+exec <&3-
+if [[ $stderr == *FAILURE* ]]; then
+    exit 1
+fi


### PR DESCRIPTION
- Builds are passing when they shouldn't.  Probably due to running the Gradle daemon.
- We weren't installing protoc