### PR TITLE
Added missing copyright headers, and changed logic around ambiguous node property value types

### DIFF
--- a/grabbit/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
+++ b/grabbit/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.apache.jackrabbit.value.DateValue

--- a/grabbit/src/main/groovy/com/twcable/grabbit/jcr/ProtoNodeDecorator.groovy
+++ b/grabbit/src/main/groovy/com/twcable/grabbit/jcr/ProtoNodeDecorator.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.twcable.grabbit.proto.NodeProtos.Node as ProtoNode
 import com.twcable.grabbit.proto.NodeProtos.Value as ProtoValue
 import groovy.transform.CompileStatic

--- a/grabbit/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
+++ b/grabbit/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.twcable.grabbit.DateUtil
 import com.twcable.grabbit.proto.NodeProtos.Property as ProtoProperty
 import com.twcable.grabbit.proto.NodeProtos.Value as ProtoValue

--- a/grabbit/src/test/groovy/com/twcable/grabbit/jcr/JCRNodeDecoratorSpec.groovy
+++ b/grabbit/src/test/groovy/com/twcable/grabbit/jcr/JCRNodeDecoratorSpec.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.day.cq.commons.jcr.JcrConstants
 import spock.lang.Specification
 

--- a/grabbit/src/test/groovy/com/twcable/grabbit/jcr/ProtoNodeDecoratorSpec.groovy
+++ b/grabbit/src/test/groovy/com/twcable/grabbit/jcr/ProtoNodeDecoratorSpec.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.day.cq.commons.jcr.JcrConstants
 import com.twcable.grabbit.proto.NodeProtos
 import com.twcable.grabbit.proto.NodeProtos.Node as ProtoNode

--- a/grabbit/src/test/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecoratorSpec.groovy
+++ b/grabbit/src/test/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecoratorSpec.groovy
@@ -1,5 +1,21 @@
 package com.twcable.grabbit.jcr
 
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import com.day.cq.commons.jcr.JcrConstants
 import com.google.protobuf.ByteString
 import com.twcable.grabbit.proto.NodeProtos.Property as PropertyProto


### PR DESCRIPTION
Changes : 

* Changed to not key off message in ValueFormatException.  Rather than "retrofitting" the property value coming across the wire, to the property value cardinality on the client (e.g ["foo", "bar"] -> "foo", or "foo" -> ["foo"]), we simply rewrite, and accept the property value cardinality type of the server.   

* Handles the case of a server sending a completely different property value type for a given property name.   

* Added missing copyright headers 