### PR TITLE
Delta content

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A `json` configuration file of following format is used to configure Grabbit.
     "serverPassword" : "<password>",
     "serverHost" : "some.other.server",
     "serverPort" : "4502",
+    "deltaContent" : true,
     "pathConfigurations" :  [
         {
             "path" : "/content/someContent",
@@ -133,6 +134,8 @@ A `json` configuration file of following format is used to configure Grabbit.
     * __path__: The path to recursively grab content from.
 
 #### Optional fields
+
+* __deltaContent__: boolean, where ```false``` has grabbit sync & overwrite all content nodes regardles of date properties, and ```true``` syncs only 'delta' or changed content. Changed content is determined by comparing either of the jcr:lastModified, cq:lastModified, or jcr:created Date with the Date when the path was successfully synced as recorded by the Grabbit Client. Thus, deltaContent will only work with paths that remained the same between two runs. Nodes without any date properties will also be synced, so as not to miss new content of unstructured nodes.
 
 Under "path configurations"
 

--- a/grabbit/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
+++ b/grabbit/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
@@ -77,11 +77,7 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, Node> {
             final Date afterDate = DateUtil.getDateFromISOString(contentAfterDate)
             log.debug "ContentAfterDate received : ${afterDate}. Will ignore content created or modified before the afterDate"
             final date = getDate(jcrNode)
-            if (!date) {
-                //we want delta content but node doesn't have any date property to compare with. So we ignore it
-                return null
-            }
-            if (date.before(afterDate)) {
+            if (date && date.before(afterDate)) { //if there are no date properties, we treat nodes as new
                 log.debug "Not sending any data older than ${afterDate}"
                 return null
             }
@@ -165,14 +161,14 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, Node> {
      */
     private static Date getDate(JcrNode jcrNode) {
         final String CQ_LAST_MODIFIED = "cq:lastModified"
-        if (jcrNode.hasProperty(JCR_CREATED)) {
-            return jcrNode.getProperty(JCR_CREATED).date.time
-        }
-        else if (jcrNode.hasProperty(JCR_LASTMODIFIED)) {
+        if (jcrNode.hasProperty(JCR_LASTMODIFIED)) {
             return jcrNode.getProperty(JCR_LASTMODIFIED).date.time
         }
         else if (jcrNode.hasProperty(CQ_LAST_MODIFIED)) {
             return jcrNode.getProperty(CQ_LAST_MODIFIED).date.time
+        }
+        else if (jcrNode.hasProperty(JCR_CREATED)) {
+            return jcrNode.getProperty(JCR_CREATED).date.time
         }
         return null
     }


### PR DESCRIPTION
testing and documenting deltaContent setting as detailed in https://github.com/TWCable/grabbit/issues/39

With this setting on, grabbit should now appropriately sync only content which was added or changed since the previous grabbit sync date. Tested with various node properties and sizes / scopes of changes and paths.

to test, run a grabbit sync to a local instance with deltaContent as 'true'. Add or change components on a path to be synced, then sync again and make sure only those nodes are synced across (the grabbit-start-monitor will show how many nodes were copied). 

@jdigger @sikarwarvimal @masroormohammed for CR/Testing.