### PR TITLE
AEM 6.1 - Update Grabbit 4.x build so that OOTB dependencies are properly excluded

### DIFF
--- a/grabbit/build.gradle
+++ b/grabbit/build.gradle
@@ -82,10 +82,15 @@ configurations.cq_package {
     exclude group: 'com.sun.xml.bind'
     exclude group: 'aopalliance', module: 'aopalliance'
     exclude group: 'javax.xml.stream'
+    exclude group: 'javax.jcr', module: 'jcr'
 
-    // use CQ's logging, not logback
+    // use AEM's logging, not logback
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'ch.qos.logback', module: 'logback-core'
+
+    // Slf4j is provided by AEM
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+    exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
 
     // excluding Joda Time too as AEM provides its own in com.day.commons.osgi.wrapper.joda-time
     exclude group: 'joda-time', module: 'joda-time'
@@ -95,8 +100,17 @@ configurations.cq_package {
     exclude group: 'com.day.cq.workflow', module: 'cq-workflow-console'
 
     exclude group: 'org.apache.felix', module: 'org.apache.felix.scr.annotations'
+    exclude group: 'org.apache.felix', module: 'org.osgi.core'
+    exclude group: 'org.apache.felix', module: 'org.osgi.compendium'
 
     exclude group: 'org.apache.commons', module: 'commons-lang3'
+    exclude group: 'org.apache.jackrabbit', module:'jackrabbit-jcr-commons'
+    exclude group: 'commons-io', module: 'commons-io'
+
+    //Exclude Apache Sling Libraries
+    exclude group: 'org.apache.sling', module: 'org.apache.sling.api'
+    exclude group: 'org.apache.sling', module:'org.apache.sling.jcr.resource'
+    exclude group: 'org.apache.sling', module: 'org.apache.sling.jcr.api'
 
     // 6.x exclude bundles
     exclude group: 'com.google.guava', module: 'guava'

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,11 +13,11 @@ commons_collections_version = 3.2.1
 commons_io_version = 1.4
 commons_lang_version = 3.3.2
 commons_text_version = 1.1.8
-/*
-* Currently using an "older" version of cq_workflow_console to compile locally since this is the latest version that is available publicly.  
-* Fortunately, the later version used on 6.1 does not have any API incompatibilities with this version
-*/ 
+
+# Currently using an "older" version of cq_workflow_console to compile locally since this is the latest version that is available publicly.
+# Fortunately, the later version used on 6.1 does not have any API incompatibilities with this version
 cq_workflow_console_version = 5.6.6
+
 felix_osgi_version = 1.4.0
 gradle_plugins_version = 3.0.1
 granite_version = 5.12.2
@@ -38,6 +38,7 @@ protobuf_gradle_plugin_version = 0.9.1
 scr_annotations_version = 1.7.0
 servicemix_protobuf_java_version = 2.4.1_1
 servlet_api_version = 2.5
+slf4j_version = 1.7.6
 sling_api_version = 2.9.0
 sling_commons_testing_version = 2.0.12
 sling_commons_version = 2.2.0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,6 @@ dependencies {
 
     // Apache Sling libraries
     compile "org.apache.sling:org.apache.sling.api:${sling_api_version}"
-    // compile "org.apache.sling:org.apache.sling.jcr.api:${sling_commons_version}"
     compile "org.apache.sling:org.apache.sling.jcr.resource:${sling_jcr_resource_version}"
 
     // Apache Felix libraries
@@ -37,13 +36,8 @@ dependencies {
     compile "org.apache.sling:org.apache.sling.jcr.api:${sling_commons_version}"
 
     // Logging
-    def slf4j_version = "1.7.6"
     compile "org.slf4j:slf4j-api:${slf4j_version}"
     compile "org.slf4j:jcl-over-slf4j:${slf4j_version}"
-    runtime "ch.qos.logback:logback-classic:${logback_version}"
-
-    // StAX library
-    compile "org.codehaus.woodstox:woodstox-core-asl:${woodstox_version}"
 
     // Servlet/JSP libraries
     compile "javax.servlet:servlet-api:${servlet_api_version}"
@@ -100,10 +94,6 @@ dependencies {
     testCompile "org.objenesis:objenesis:${objenesis_version}"
 
 }
-
-// workaround for http://issues.gradle.org/browse/GRADLE-1682
-configurations.runtime.exclude group: 'org.apache.felix', module: 'org.osgi.foundation'
-configurations.runtime.exclude group: 'org.apache.felix', module: 'javax.servlet'
 
 configurations.compile {
     exclude group: 'commons-logging', module: 'commons-logging'


### PR DESCRIPTION
Fix for #79 

@jbornemann @jdigger @jazeren1 please take a look. To test, install / uninstall this Grabbit build a bunch of times and each time, it should be MUCH smoother at doing so.

Also, since you will likely have another version of Grabbit already installed, please : 

1. Delete `/apps/grabbit/install` & `/etc/packages/twc/Grabbit.zip` from CRXDE
2.  Wait for AEM to stabilize (look in the logs and /system/console/bundles should also show all active)
3. Restart AEM
4. Then install this build
5. Try install and uninstall of this build a bunch of times
