### PR TITLE
Grabbit-Issue-22 Providing Root Resource Provider for Grabbit

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/ClientJobStatus.groovy
+++ b/src/main/groovy/com/twcable/grabbit/ClientJobStatus.groovy
@@ -125,4 +125,18 @@ class ClientJobStatus {
             it.transactionID == transactionID
         } as Collection<ClientJobStatus>
     }
+
+    /**
+     * @param explorer The job explorer to query.
+     * @throws IllegalArgumentException If explorer is null.
+     * @return a {@link Collection} representing all transaction ids; or an empty collection if there are no transactions.
+     * This may mean that the transactions never existed, or that the data store for the JCR job repository was externally modified
+     */
+    @Nonnull
+    static Collection<String> getAllTransactions(@Nonnull final JobExplorer explorer) {
+        if(explorer == null) throw new IllegalArgumentException("jobExplorer == null")
+        getAll(explorer).collect {
+            it.transactionID
+        }.unique() as Collection<String>
+    }
 }

--- a/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitJobServlet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitJobServlet.groovy
@@ -104,7 +104,7 @@ class GrabbitJobServlet extends SlingAllMethodsServlet {
         }
         log.warn "Bad request to receive job status for : ${request.pathInfo}. A job ID was not provided in the request."
         response.setStatus(SC_BAD_REQUEST)
-        response.writer.write("Request was made to get the status of a job, but no job ID was provided for ${request.pathInfo}.")
+        response.writer.write("Request was made to get the status of a job, but no job ID was provided for ${request.pathInfo}. Try again with ${request.pathInfo}/<Job-ID> or ${request.pathInfo}/all.")
     }
 
     /**

--- a/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitRootServlet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitRootServlet.groovy
@@ -1,0 +1,53 @@
+package com.twcable.grabbit.client.servlets
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.apache.felix.scr.annotations.sling.SlingServlet
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.apache.sling.api.servlets.SlingAllMethodsServlet
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Root resource for /grabbit requests.
+ * Acts as a handler for {@link com.twcable.grabbit.resources.RootResource} resource.
+ */
+@Slf4j
+@CompileStatic
+@SlingServlet(methods = ['GET'], resourceTypes = ['twcable:grabbit'])
+class GrabbitRootServlet extends  SlingAllMethodsServlet {
+
+    /**
+     * This method gets called when a request is made to either Grabbit Root resource directly (/grabbit) or any invalid
+     * URL under it.
+     * Response will contain links to valid resources' urls under Grabbit Root url, in accordance with HATEOAS.
+     * A hypermedia-driven response provides information to navigate Grabbit's resources dynamically, by including
+     * valid hypermedia links along with the response.
+     * For reference, {@see https://spring.io/understanding/HATEOAS}
+     *
+     * From Grabbit Root resource, Valid resources are
+     * - Grabbit's Job Resource (/grabbit/job)
+     * - Grabbit's Content Resource (/grabbit/content)
+     * - Grabbit's Transaction Resource (/grabbit/transaction)
+     */
+    @Override
+    void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) {
+        response.setContentType("text/html")
+        response.setStatus(SC_OK)
+        response.writer.write this.class.getResourceAsStream("RootResource.txt").text
+    }
+}

--- a/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitTransactionServlet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/servlets/GrabbitTransactionServlet.groovy
@@ -42,10 +42,16 @@ import static javax.servlet.http.HttpServletResponse.SC_OK
 @SlingServlet(methods = ['GET'], resourceTypes = ['twcable:grabbit/transaction'])
 class GrabbitTransactionServlet extends SlingSafeMethodsServlet {
 
+    //A "special" meta-jobID that allows for the status of all transactions to be queried.
+    static final String ALL_TRANSACTION_ID = "all"
+
     @Reference(bind = 'setConfigurableApplicationContext')
     ConfigurableApplicationContext configurableApplicationContext
 
     /**
+     * Used for querying the status of a transaction id for jobs executed in that transaction.(eg /grabbit/transaction/123, where 123 is the transaction ID)
+     * A special case is {@code ALL_TRANSACTION_ID}, to which this servlet will respond with the list of all transactions recorded.
+     *
      * @param request The request for querying a transaction.
      * @param response The response for the query. Will respond with an HTTP 200, and JSON status string if the transaction is found.
      * If the transaction isn't found or no transactionID is provided, will respond with an HTTP 400, and a description of what went wrong.
@@ -57,8 +63,19 @@ class GrabbitTransactionServlet extends SlingSafeMethodsServlet {
             String transactionIDString = request.resource.resourceMetadata[TransactionResource.TRANSACTION_ID_KEY]
             // Guard against the transactionID coming back as null or empty
             if(transactionIDString != null && !transactionIDString.empty) {
-                //At this point we know we at least have something as the "transactionID." It may still not be a valid numeric ID
-                transactionID = transactionIDString.toLong()
+                if(ALL_TRANSACTION_ID.equals(transactionIDString)){
+                    final JobExplorer jobExplorer = configurableApplicationContext.getBean("clientJobExplorer", JobExplorer)
+                    final Collection<String> transactionIds = ClientJobStatus.getAllTransactions(jobExplorer)
+                    response.setStatus(SC_OK)
+                    response.setContentType("text/html")
+                    response.writer.write this.class.getResourceAsStream("GrabbitTransactionResource-all.txt").text + transactionIds.collect {
+                        "<a href=/grabbit/transaction/${it}>${it}</a><br/>"
+                    }.join(" ")
+                    return
+                }else{
+                    //At this point, we know we at least have something as the "transactionID". It may still not be a valid numeric ID
+                    transactionID = transactionIDString.toLong()
+                }
             }
         } catch(NumberFormatException ex) {
             log.warn "Bad request to receive transaction status for : ${request.pathInfo}. Transaction ID's must be numeric."
@@ -86,6 +103,7 @@ class GrabbitTransactionServlet extends SlingSafeMethodsServlet {
         }
         log.warn "Bad request to receive transaction status for : ${request.pathInfo}. A transactionID was not provided."
         response.setStatus(SC_BAD_REQUEST)
-        response.writer.write("Request was made to get status of a transaction, but a transactionID was not provided for ${request.pathInfo}.")
+        response.setContentType("text/html")
+        response.writer.write this.class.getResourceAsStream("GrabbitTransactionResource-BadRequest.txt").text
     }
 }

--- a/src/main/groovy/com/twcable/grabbit/resources/CleanJobRepositoryResource.groovy
+++ b/src/main/groovy/com/twcable/grabbit/resources/CleanJobRepositoryResource.groovy
@@ -18,7 +18,6 @@ package com.twcable.grabbit.resources
 
 import groovy.transform.CompileStatic
 import org.apache.sling.api.resource.ResourceResolver
-import org.apache.sling.api.resource.SyntheticResource
 
 import javax.annotation.Nonnull
 
@@ -28,9 +27,9 @@ import javax.annotation.Nonnull
  * Queried from {@link com.twcable.grabbit.spring.batch.repository.servlets.GrabbitCleanJobRepositoryServlet}.
  */
 @CompileStatic
-class CleanJobRepositoryResource extends SyntheticResource {
+class CleanJobRepositoryResource extends RootResource {
 
-    public static final String CLEAN_JOBREPOSITORY_RESOURCE_TYPE = "twcable:grabbit/jobrepository/clean"
+    public static final String CLEAN_JOBREPOSITORY_RESOURCE_TYPE = "${ROOT_RESOURCE_TYPE}/jobrepository/clean"
 
     CleanJobRepositoryResource(@Nonnull final ResourceResolver resourceResolver, @Nonnull final String resolutionPath) {
         super(resourceResolver, resolutionPath, CLEAN_JOBREPOSITORY_RESOURCE_TYPE)
@@ -40,5 +39,10 @@ class CleanJobRepositoryResource extends SyntheticResource {
     @Override
     String getResourceType() {
         return CLEAN_JOBREPOSITORY_RESOURCE_TYPE
+    }
+
+    @Override
+    String getResourceSuperType(){
+        return ROOT_RESOURCE_TYPE
     }
 }

--- a/src/main/groovy/com/twcable/grabbit/resources/GrabbitResourceProvider.groovy
+++ b/src/main/groovy/com/twcable/grabbit/resources/GrabbitResourceProvider.groovy
@@ -83,8 +83,8 @@ class GrabbitResourceProvider implements ResourceProvider {
                 log.debug "Resolving ${path} to CleanJobRepositoryResource"
                 return new CleanJobRepositoryResource(resolver, path)
             default:
-                //Should provide a root resource for /grabbit, along with HATEOS style for this link, and other links. https://github.com/TWCable/grabbit/issues/22
-                return null
+                log.debug "Resolving ${path} to RootResource"
+                return new RootResource(resolver, path)
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/resources/JobResource.groovy
+++ b/src/main/groovy/com/twcable/grabbit/resources/JobResource.groovy
@@ -18,7 +18,6 @@ package com.twcable.grabbit.resources
 
 import groovy.transform.CompileStatic
 import org.apache.sling.api.resource.ResourceResolver
-import org.apache.sling.api.resource.SyntheticResource
 
 import javax.annotation.Nonnull
 import java.util.regex.Matcher
@@ -28,10 +27,10 @@ import java.util.regex.Matcher
  * Queried from {@link com.twcable.grabbit.client.servlets.GrabbitJobServlet}.
  */
 @CompileStatic
-class JobResource extends SyntheticResource {
+class JobResource extends RootResource {
 
-    public static final String JOB_RESOURCE_TYPE = "twcable:grabbit/job"
-    public static final String JOB_EXECUTION_ID_KEY = "twcable:grabbit:jobresource.jobExecutionId"
+    public static final String JOB_RESOURCE_TYPE = "${ROOT_RESOURCE_TYPE}/job"
+    public static final String JOB_EXECUTION_ID_KEY = "${ROOT_RESOURCE_TYPE}:jobresource.jobExecutionId"
 
     JobResource(@Nonnull final ResourceResolver resourceResolver, @Nonnull final String resolutionPath) {
         super(resourceResolver, resolutionPath, JOB_RESOURCE_TYPE)
@@ -54,5 +53,10 @@ class JobResource extends SyntheticResource {
     @Override
     String getResourceType() {
         return JOB_RESOURCE_TYPE
+    }
+
+    @Override
+    String getResourceSuperType(){
+        return ROOT_RESOURCE_TYPE
     }
 }

--- a/src/main/groovy/com/twcable/grabbit/resources/RootResource.groovy
+++ b/src/main/groovy/com/twcable/grabbit/resources/RootResource.groovy
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2015 Time Warner Cable, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,37 +12,31 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Representation of a Grabbit's Root Resource provided by {@link GrabbitResourceProvider}.
+ * Queried from {@link com.twcable.grabbit.client.servlets.GrabbitRootServlet}
  */
 
 package com.twcable.grabbit.resources
 
 import groovy.transform.CompileStatic
 import org.apache.sling.api.resource.ResourceResolver
+import org.apache.sling.api.resource.SyntheticResource
 
 import javax.annotation.Nonnull
 
-/**
- * A resource representing some content to be streamed from a Grabbit instance.
- * provided by {@link GrabbitResourceProvider}.
- * Queried from {@link com.twcable.grabbit.server.GrabbitContentPullServlet}.
- */
 @CompileStatic
-class ContentResource extends RootResource {
+class RootResource extends SyntheticResource  {
 
-    public static final String CONTENT_RESOURCE_TYPE = "${ROOT_RESOURCE_TYPE}/content"
+    static final String ROOT_RESOURCE_TYPE = "twcable:grabbit"
 
-    ContentResource(@Nonnull final ResourceResolver resourceResolver, @Nonnull final String resolutionPath) {
-        super(resourceResolver, resolutionPath, CONTENT_RESOURCE_TYPE)
+    RootResource(@Nonnull final ResourceResolver resourceResolver,@Nonnull final String resolutionPath,
+                 String resourceType = ROOT_RESOURCE_TYPE) {
+        super(resourceResolver, resolutionPath, resourceType)
     }
-
 
     @Override
     String getResourceType() {
-        return CONTENT_RESOURCE_TYPE
-    }
-
-    @Override
-    String getResourceSuperType(){
         return ROOT_RESOURCE_TYPE
     }
 }

--- a/src/main/groovy/com/twcable/grabbit/resources/TransactionResource.groovy
+++ b/src/main/groovy/com/twcable/grabbit/resources/TransactionResource.groovy
@@ -18,7 +18,6 @@ package com.twcable.grabbit.resources
 
 import groovy.transform.CompileStatic
 import org.apache.sling.api.resource.ResourceResolver
-import org.apache.sling.api.resource.SyntheticResource
 
 import javax.annotation.Nonnull
 import java.util.regex.Matcher
@@ -30,10 +29,10 @@ import java.util.regex.Matcher
  * Queried from {@link com.twcable.grabbit.client.servlets.GrabbitTransactionServlet}.
  */
 @CompileStatic
-class TransactionResource extends SyntheticResource {
+class TransactionResource extends RootResource {
 
-    public static final String TRANSACTION_RESOURCE_TYPE = "twcable:grabbit/transaction"
-    public static final String TRANSACTION_ID_KEY = "twcable:grabbit:transactionresource.transactionID"
+    public static final String TRANSACTION_RESOURCE_TYPE = "${ROOT_RESOURCE_TYPE}/transaction"
+    public static final String TRANSACTION_ID_KEY = "${ROOT_RESOURCE_TYPE}:transactionresource.transactionID"
 
     TransactionResource(@Nonnull final ResourceResolver resourceResolver, @Nonnull final String resolutionPath) {
         super(resourceResolver, resolutionPath, TRANSACTION_RESOURCE_TYPE)
@@ -56,5 +55,10 @@ class TransactionResource extends SyntheticResource {
     @Override
     String getResourceType() {
         return TRANSACTION_RESOURCE_TYPE
+    }
+
+    @Override
+    String getResourceSuperType(){
+        return ROOT_RESOURCE_TYPE
     }
 }

--- a/src/main/resources/com/twcable/grabbit/client/servlets/GrabbitTransactionResource-BadRequest.txt
+++ b/src/main/resources/com/twcable/grabbit/client/servlets/GrabbitTransactionResource-BadRequest.txt
@@ -1,0 +1,2 @@
+Request was made to get status of a transaction, but a transactionID was not provided for /grabbit/transaction.<br/>
+<a href='/grabbit/transaction/all'>Click</a> to view a list of all transactions.

--- a/src/main/resources/com/twcable/grabbit/client/servlets/GrabbitTransactionResource-all.txt
+++ b/src/main/resources/com/twcable/grabbit/client/servlets/GrabbitTransactionResource-all.txt
@@ -1,0 +1,1 @@
+Click on one of the following Transaction ids for Job Details <br/>

--- a/src/main/resources/com/twcable/grabbit/client/servlets/RootResource.txt
+++ b/src/main/resources/com/twcable/grabbit/client/servlets/RootResource.txt
@@ -1,0 +1,13 @@
+Grabbit Does not support direct requests on this url.<br/>
+
+Visit one of the following links for more info!<br/>
+
+<a href="/grabbit/job">
+    Job Requests
+</a> <br/>
+<a href="/grabbit/content">
+    Content Requests
+</a> <br/>
+<a href="/grabbit/transaction">
+    Transaction Requests
+</a>

--- a/src/test/groovy/com/twcable/grabbit/ClientJobStatusSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/ClientJobStatusSpec.groovy
@@ -9,6 +9,7 @@ import org.springframework.batch.core.JobParameters
 import org.springframework.batch.core.StepExecution
 import org.springframework.batch.core.explore.JobExplorer
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /*
  * Copyright 2015 Time Warner Cable, Inc.
@@ -168,6 +169,19 @@ class ClientJobStatusSpec extends Specification {
         status.empty
     }
 
+    def "If no jobs have ever been run, getAllTransactions returns an empty list"() {
+        given:
+        final JobExplorer jobExplorer = Mock(JobExplorer) {
+            getJobInstances(ClientBatchJob.JOB_NAME, 0, Integer.MAX_VALUE) >> null
+        }
+
+        when:
+        final Collection<String> transactionList = ClientJobStatus.getAllTransactions(jobExplorer)
+
+        then:
+        transactionList.empty
+    }
+
     def "Get status of all jobs ever run"() {
         given:
         final JobInstance jobInstance = Mock(JobInstance)
@@ -222,5 +236,54 @@ class ClientJobStatusSpec extends Specification {
         then:
         status.size() == 1
         status.get(0).transactionID == 456L
+    }
+
+    @Unroll
+    def "If there are different jobs with same transaction id, then getAllTransactions will return unique Collection of transaction ids"() {
+        given:
+        final JobInstance jobInstance = Mock(JobInstance)
+        final JobInstance anotherJobInstance = Mock(JobInstance)
+        final JobExplorer jobExplorer = Mock(JobExplorer) {
+            getJobInstances(ClientBatchJob.JOB_NAME, 0, Integer.MAX_VALUE) >> [
+                    jobInstance,anotherJobInstance
+            ]
+            getJobExecutions(jobInstance) >> [
+                    Mock(JobExecution) {
+                        getId() >> jobId
+                    }
+            ]
+            getJobExecutions(anotherJobInstance) >> [
+                    Mock(JobExecution) {
+                        getId() >> anotherJobId
+                    }
+            ]
+            getJobExecution(jobId) >> Mock(GrabbitJobExecution) {
+                getJobParameters() >> Mock(JobParameters)
+                isRunning() >> false
+                getEndTime() >> Mock(Date)
+                getStartTime() >> Mock(Date)
+                getTransactionID() >> transactionId
+            }
+            getJobExecution(anotherJobId) >> Mock(GrabbitJobExecution) {
+                getJobParameters() >> Mock(JobParameters)
+                isRunning() >> false
+                getEndTime() >> Mock(Date)
+                getStartTime() >> Mock(Date)
+                getTransactionID() >> anotherTransactionId
+            }
+        }
+
+        when:
+        final Collection<String> status = ClientJobStatus.getAllTransactions(jobExplorer)
+
+        then:
+        status.size() == size
+
+        where:
+        jobId << [1L, 2L]
+        anotherJobId << [3L, 4L]
+        transactionId << [100L, 100L]
+        anotherTransactionId << [100L, 101L]
+        size << [1, 2]
     }
 }

--- a/src/test/groovy/com/twcable/grabbit/client/servlets/GrabbitRootServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/client/servlets/GrabbitRootServletSpec.groovy
@@ -1,0 +1,49 @@
+package twcable.grabbit.client.servlets
+
+import com.twcable.grabbit.client.servlets.GrabbitRootServlet
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.apache.sling.api.resource.Resource
+import static javax.servlet.http.HttpServletResponse.SC_OK
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/*
+ * Copyright 2015 Time Warner Cable, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class GrabbitRootServletSpec extends Specification {
+
+    @Unroll
+    def "Request to #path will result in OK response"() {
+        given:
+        final request = Mock(SlingHttpServletRequest) {
+            getResource() >> Mock(Resource) {
+            }
+            getPathInfo() >> "/grabbit/${path}"
+        }
+        final response = Mock(SlingHttpServletResponse) {
+            1 * setStatus(SC_OK)
+            getWriter() >> Mock(PrintWriter)
+        }
+
+        final grabbitRootServlet = new GrabbitRootServlet()
+
+        expect:
+        grabbitRootServlet.doGet(request, response)
+
+        where:
+        path << ["", null, "invalid", 1]
+    }
+}

--- a/src/test/groovy/com/twcable/grabbit/client/servlets/GrabbitTransactionServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/client/servlets/GrabbitTransactionServletSpec.groovy
@@ -55,6 +55,31 @@ class GrabbitTransactionServletSpec extends Specification {
         transactionServlet.doGet(request, response)
     }
 
+    def "A request for transaction status with an transactionId 'all' results in a OK response"() {
+        given:
+        final request = Mock(SlingHttpServletRequest) {
+            getResource() >> Mock(Resource) {
+                getResourceMetadata() >> Mock(ResourceMetadata) {
+                    get(TransactionResource.TRANSACTION_ID_KEY) >> "all"
+                }
+            }
+            getPathInfo() >> "/grabbit/transaction/all"
+        }
+        final response = Mock(SlingHttpServletResponse) {
+            1 * setStatus(SC_OK)
+            getWriter() >> Mock(PrintWriter)
+        }
+        final applicationContext = Mock(ConfigurableApplicationContext) {
+            getBean("clientJobExplorer", JobExplorer) >> Mock(JobExplorer)
+        }
+
+        final transactionServlet = new GrabbitTransactionServlet()
+        transactionServlet.setConfigurableApplicationContext(applicationContext)
+
+        expect:
+        transactionServlet.doGet(request, response)
+    }
+
     def "If no transactionId is provided for a transaction status request, we respond with a bad request response"() {
         given:
         final request = Mock(SlingHttpServletRequest) {


### PR DESCRIPTION
[Grabbit-issue-22](https://github.com/TWCable/grabbit/issues/22): Providing a self documentation for all legal paths from **/grabbit/** instead of giving a 404

- [x] No 404 on calling __/grabbit__ URL
- [x] Some documentation enhancements for GrabbitJobServlet.groovy and GrabbitContentPullServlet.groovy

@jdigger, @sagarsane, @jbornemann, @jazeren1 
Please have a look at this one