### PR TITLE
Parent Node Calculation

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/validation/ValidJobDecider.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/validation/ValidJobDecider.groovy
@@ -64,7 +64,7 @@ class ValidJobDecider implements JobExecutionDecider {
         //No parent, so nothing to worry about
         if(parts.length <= 2) return JOB_VALID
 
-        final parentPath = jobPath - "/${parts[-1]}"
+        final parentPath = parts[0..-2].join('/')
         final Session session = theSession()
         try {
             session.getNode(parentPath)


### PR DESCRIPTION
If the parent of the node to be replicated starts with the name of the node to be replicated, the - operator would yield incorrect results.  Example:


def jobPath​​ = "/content/dam/folder123/fo";
jobPath = jobPath.replaceFirst(/\/$/, '')
final parts = jobPath.split('/')
final parentPath = jobPath - "/${parts[-1]}"


​