### PR TITLE
Pull setLastModifiedDate() out of JCRNodesProcessor and into ProtoNodeDecorator

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -88,8 +88,7 @@ class JcrNodesWriter implements ItemWriter<ProtoNode>, ItemWriteListener {
     }
 
     private static void writeToJcr(ProtoNode nodeProto, Session session) {
-        JCRNodeDecorator jcrNode = ProtoNodeDecorator.createFrom(nodeProto).writeToJcr(session)
-        jcrNode.setLastModified()
+        ProtoNodeDecorator.createFrom(nodeProto).writeToJcr(session)
     }
 
     private Session theSession() {

--- a/src/main/groovy/com/twcable/grabbit/jcr/ACLProtoNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ACLProtoNodeDecorator.groovy
@@ -54,7 +54,7 @@ class ACLProtoNodeDecorator extends ProtoNodeDecorator {
 
 
     @Override
-    JCRNodeDecorator writeToJcr(@Nonnull Session session) {
+    protected JCRNodeDecorator writeNode(@Nonnull Session session) {
         /**
          * We don't write the rep:policy node directly. Rather, we find the rep:policy node's ACE(s) and add them to the
          * owner's existing policy; or we add them to a new policy.

--- a/src/main/groovy/com/twcable/grabbit/jcr/AuthorizableProtoNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/AuthorizableProtoNodeDecorator.groovy
@@ -52,7 +52,7 @@ class AuthorizableProtoNodeDecorator extends ProtoNodeDecorator {
 
 
     @Override
-    JCRNodeDecorator writeToJcr(@Nonnull Session session) {
+    protected JCRNodeDecorator writeNode(@Nonnull Session session) {
         if(!checkSecurityPermissions()) {
             throw new InsufficientGrabbitPrivilegeException("JVM Permissions needed by Grabbit to sync Users/Groups were not found. See log for specific permissions needed, and add these to your security manager; or do not sync users and groups." +
                                                             "Unfortunately, the way Jackrabbit goes about certain things requires us to do a bit of hacking in order to sync Authorizables securely, and efficiently.")

--- a/src/main/groovy/com/twcable/grabbit/jcr/DefaultProtoNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/DefaultProtoNodeDecorator.groovy
@@ -42,7 +42,7 @@ class DefaultProtoNodeDecorator extends ProtoNodeDecorator {
 
 
     @Override
-    JCRNodeDecorator writeToJcr(@Nonnull Session session) {
+    protected JCRNodeDecorator writeNode(@Nonnull Session session) {
         final jcrNode = getOrCreateNode(session)
         //Write mixin types first to avoid InvalidConstraintExceptions
         final mixinProperty = getMixinProperty()

--- a/src/main/groovy/com/twcable/grabbit/jcr/ProtoNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ProtoNodeDecorator.groovy
@@ -32,7 +32,7 @@ abstract class ProtoNodeDecorator {
 
     protected String nameOverride
 
-    abstract JCRNodeDecorator writeToJcr(@Nonnull Session session)
+    protected abstract JCRNodeDecorator writeNode(@Nonnull Session session)
 
     static ProtoNodeDecorator createFrom(@Nonnull ProtoNode node, String nameOverride = null) {
         if(!node) throw new IllegalArgumentException("node must not be null!")
@@ -46,6 +46,14 @@ abstract class ProtoNodeDecorator {
         }
         return new DefaultProtoNodeDecorator(node, protoProperties, nameOverride)
     }
+
+
+    JCRNodeDecorator writeToJcr(@Nonnull Session session) {
+        final JCRNodeDecorator writtenNode = writeNode(session)
+        writtenNode.setLastModified()
+        return writtenNode
+    }
+
 
     boolean hasProperty(String propertyName) {
         propertiesList.any{ it.name == propertyName }

--- a/src/test/groovy/com/twcable/grabbit/jcr/ACLProtoNodeDecoratorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/jcr/ACLProtoNodeDecoratorSpec.groovy
@@ -29,6 +29,7 @@ import javax.jcr.PathNotFoundException
 import javax.jcr.Property
 import javax.jcr.PropertyIterator
 import javax.jcr.Session
+import javax.jcr.nodetype.NodeType
 import javax.jcr.security.AccessControlEntry
 import javax.jcr.security.AccessControlManager
 import javax.jcr.security.AccessControlPolicy
@@ -148,6 +149,9 @@ class ACLProtoNodeDecoratorSpec extends Specification {
                 it.getString() >> NT_REP_ACL
             }
             it.getName() >> "${ownerNodePath}/rep:policy"
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
+            }
         }
         final Session session = Mock(Session) {
             1 * it.save()
@@ -221,6 +225,9 @@ class ACLProtoNodeDecoratorSpec extends Specification {
                 it.getString() >> NT_REP_ACL
             }
             it.getName() >> "${ownerNodePath}/rep:policy"
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
+            }
         }
         final Session session = Mock(Session) {
             2 * it.save()
@@ -337,6 +344,9 @@ class ACLProtoNodeDecoratorSpec extends Specification {
                 it.getString() >> 'nt:unstructured'
             }
             it.getName() >> ownerNodePath
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
+            }
         }
         final Session session = Mock(Session) {
             it.getNode(ownerNodePath) >> ownerNode

--- a/src/test/groovy/com/twcable/grabbit/jcr/AuthorizableProtoNodeDecoratorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/jcr/AuthorizableProtoNodeDecoratorSpec.groovy
@@ -26,6 +26,7 @@ import javax.jcr.Node
 import javax.jcr.Property
 import javax.jcr.PropertyIterator
 import javax.jcr.Session
+import javax.jcr.nodetype.NodeType
 import org.apache.jackrabbit.api.security.user.Authorizable
 import org.apache.jackrabbit.api.security.user.Group
 import org.apache.jackrabbit.api.security.user.User
@@ -139,6 +140,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
                 getProperties() >> Mock(PropertyIterator) {
                     it.toList() >> []
                 }
+                it.getPrimaryNodeType() >> Mock(NodeType) {
+                    it.canSetProperty(_, _) >> false
+                }
             }
         }
         final protoNodeDecorator = theProtoNodeDecorator(false, false, false) {
@@ -173,6 +177,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
                 }
                 getProperties() >> Mock(PropertyIterator) {
                     it.toList() >> []
+                }
+                it.getPrimaryNodeType() >> Mock(NodeType) {
+                    it.canSetProperty(_, _) >> false
                 }
             }
         }
@@ -209,6 +216,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
             }
             getProperties() >> Mock(PropertyIterator) {
                 it.toList() >> []
+            }
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
             }
         }
         final session = Mock(Session) {
@@ -248,6 +258,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
             getProperties() >> Mock(PropertyIterator) {
                 it.toList() >> []
             }
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
+            }
         }
         final session = Mock(Session) {
             it.getNode('newGroupPath') >> node
@@ -281,6 +294,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
             getProperties() >> Mock(PropertyIterator) {
                 it.toList() >> []
             }
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
+            }
         }
         final session = Mock(Session) {
             it.getNode('/home/users/u/newuser') >> node
@@ -313,6 +329,9 @@ class AuthorizableProtoNodeDecoratorSpec extends Specification {
             }
             getProperties() >> Mock(PropertyIterator) {
                 it.toList() >> []
+            }
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
             }
         }
         final session = Mock(Session) {

--- a/src/test/groovy/com/twcable/grabbit/jcr/DefaultProtoNodeDecoratorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/jcr/DefaultProtoNodeDecoratorSpec.groovy
@@ -20,6 +20,7 @@ import com.twcable.grabbit.proto.NodeProtos
 import com.twcable.grabbit.proto.NodeProtos.Node as ProtoNode
 import com.twcable.grabbit.proto.NodeProtos.Node.Builder as ProtoNodeBuilder
 import com.twcable.grabbit.proto.NodeProtos.Property as ProtoProperty
+import javax.jcr.nodetype.NodeType
 import spock.lang.Specification
 
 import javax.jcr.Node
@@ -125,6 +126,9 @@ class DefaultProtoNodeDecoratorSpec extends Specification {
             }
             getProperties() >> Mock(PropertyIterator) {
                 toList() >> []
+            }
+            it.getPrimaryNodeType() >> Mock(NodeType) {
+                it.canSetProperty(_, _) >> false
             }
         }
         final protoPropertyDecorators = [


### PR DESCRIPTION
@viveksachdeva @sagarsane if you could take a quick look. This is a something small I've been wanting to do. Since written required nodes don't circle back to JcrNodesWriter, setLastModified() isn't set for these nodes. With this change we will have completely segregated business logic out of the Spring Framework, and enabled delta sync to become more effective. Spring simply controls the flow now. :-) 