### PR TITLE
Issue #181: Set next jobInstanceID to last jobInstanceId + 1

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/spring/batch/repository/JcrGrabbitJobInstanceDao.groovy
+++ b/src/main/groovy/com/twcable/grabbit/spring/batch/repository/JcrGrabbitJobInstanceDao.groovy
@@ -257,10 +257,21 @@ class JcrGrabbitJobInstanceDao extends AbstractJcrDao implements GrabbitJobInsta
         if (!resolver) throw new IllegalArgumentException("resolver == null")
 
         final rootResource = resolver.getResource(JOB_INSTANCE_ROOT)
-        final nextId = (rootResource.children.asList().size() + 1) as Long
+
+        final lastInstance = rootResource?.children?.asList()?.max { Resource resource ->
+            final properties = resource.adaptTo(ValueMap)
+            properties[INSTANCE_ID] as Long
+        }
+        final lastInstanceProperties = lastInstance?.adaptTo(ValueMap)
+        Long nextId = lastInstanceProperties?.get(INSTANCE_ID) as Long
+        if (!nextId) {
+            nextId = 1
+        } else {
+            nextId += 1
+        }
+
         log.debug "Next JobInstance Id : $nextId"
         nextId
-
     }
 
     @Override

--- a/src/test/groovy/com/twcable/grabbit/spring/batch/repository/JcrGrabbitJobInstanceDaoSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/spring/batch/repository/JcrGrabbitJobInstanceDaoSpec.groovy
@@ -181,4 +181,55 @@ class JcrGrabbitJobInstanceDaoSpec extends Specification {
         result.size() == 2
     }
 
+    def "CreateJobInstance for empty repository"() {
+        setup:
+        final builder =
+                node("var",
+                        node("grabbit",
+                                node("job",
+                                        node("repository",
+                                                node("jobInstances"),
+                                                node("jobExecutions")
+                                        )
+                                )
+                        )
+                )
+        final emptyMockFactory = new SimpleResourceResolverFactory(repository(builder).build())
+
+        when:
+        final jobInstanceDao = new JcrGrabbitJobInstanceDao(emptyMockFactory)
+        final result = jobInstanceDao.createJobInstance("FirstJob", new JobParameters())
+
+        then:
+        result.id == 1
+    }
+
+    def "CreateJobInstance for partial repository"() {
+        setup:
+        final builder =
+                node("var",
+                        node("grabbit",
+                                node("job",
+                                        node("repository",
+                                                node("jobInstances",
+                                                        node("2",
+                                                                property(INSTANCE_ID, 2),
+                                                                property(NAME, "someOtherJob"),
+                                                        )
+                                                ),
+                                                node("jobExecutions")
+                                        )
+                                )
+                        )
+                )
+        final partialMockFactory = new SimpleResourceResolverFactory(repository(builder).build())
+
+        when:
+        final jobInstanceDao = new JcrGrabbitJobInstanceDao(partialMockFactory)
+        final result = jobInstanceDao.createJobInstance("FirstJob", new JobParameters())
+
+        then:
+        result.id == 3
+    }
+
 }


### PR DESCRIPTION
This fixes Issue #181 

It finds the highest jobInstanceId and increments by 1.  This way all jobInstances will sill be in chronological (ascending) order and later transactions will not conflict with earlier transactions after partially clearing some of the earlier jobInstances.