### PR TITLE
AEMSupport Document Update For Sling Login Admin Whitelist

### DIFF
--- a/docs/AEMSupport.adoc
+++ b/docs/AEMSupport.adoc
@@ -4,6 +4,7 @@
 * One-time installation of a system Fragment Bundle is needed. It can be found link:https://bintray.com/artifact/download/twcable/aem/dependencies/Sun-Misc-Fragment-Bundle-1.0.0.zip[here]
 * If running AEM 6.2+ with the AEM Deserialization Firewall enabled, link:https://bintray.com/twcable/aem/download_file?file_path=dependencies%2FGrabbit-Deserialization-Firewall-Configuration-1.0.zip[this package] is required in order
 for Grabbit to work. If running the deserialization firewall with custom blacklist/whitelist rules, check out the package description to gather which additional paths will need to be considered.
+* In Addition to the AEM Deserialization Firewall package, you would need to install link:https://bintray.com/artifact/download/twcable/aem/dependencies/Grabbit-Apache-Sling-Login-Whitelist-1.0.zip[this] to have the grabbit bundle be whitelisted with Apache Sling Login Admin.
 
 == Below details AEM version support for the various releases of Grabbit.
 ```


### PR DESCRIPTION
@sagarsane 

Updated the AEMSupportDoc to account for the Apache Sling Whitelist Admin Package, the package would need to be uploaded to bintray in the dependencies section. I do not have access to upload there so i'm adding the package here for you to do so.
[Grabbit-Apache-Sling-Login-Whitelist-1.0.zip](https://github.com/TWCable/grabbit/files/2062804/Grabbit-Apache-Sling-Login-Whitelist-1.0.zip)

To Test:
Upon installation of this package ensure you see the following screen in system/console/configMgr

<img width="1303" alt="screen shot 2018-05-30 at 3 55 38 pm" src="https://user-images.githubusercontent.com/10712665/40842719-cda600b0-657c-11e8-94a2-7547161e0b24.png">

This will ensure the var/grabbit path is created and you are able to run and/or monitor grabbit config runs.
