### PR TITLE
#2 : Updates the debug statement to only write out the node name and not the whole node

### DIFF
--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -41,7 +41,7 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
         if (servletOutputStream == null) throw new IllegalStateException("servletOutputStream must be set.")
 
         nodeProtos.each { NodeProtos.Node node ->
-            log.debug "Sending NodeProto : ${node}"
+            log.debug "Sending NodeProto : ${node.name}"
             node.writeDelimitedTo(servletOutputStream)
         }
     }


### PR DESCRIPTION
Closes #2 

@masroormohammed, @pgoodrich can you guys test this out when you get a chance? This is per the suggestion from @mzgubin in https://github.com/TWCable/grabbit/issues/2#issuecomment-398075823

To test this, it should be enough to try sending very large files (like large DAM uploads 50MB +) from Grabbit Server to Client.

