### PR TITLE
Making the content syncs more resilient

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@ group = com.twcable.grabbit
 version = 7.1.6
 
 # Please keep alphabetical
-apache_httpcore_version = 4.4.8
 apache_httpclient_version = 4.5.4
+apache_httpcore_version = 4.4.8
 cglib_nodep_version = 2.2.2
 commons_collections_version = 3.2.1
 commons_io_version = 1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,8 @@ group = com.twcable.grabbit
 version = 7.1.4-SNAPSHOT
 
 # Please keep alphabetical
+apache_httpcore_version = 4.4.8
+apache_httpclient_version = 4.5.4
 cglib_nodep_version = 2.2.2
 commons_collections_version = 3.2.1
 commons_io_version = 1.4
@@ -41,6 +43,7 @@ servlet_api_version = 2.5
 slf4j_version = 1.7.6
 sling_api_version = 2.9.0
 sling_base_version = 2.2.2
+sling_commons_json_version = 2.0.6
 sling_commons_testing_version = 2.0.12
 sling_commons_version = 2.2.0
 sling_event_version = 3.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPe
 bundleInstallRoot = /apps/grabbit/install
 
 group = com.twcable.grabbit
-version = 7.1.3
+version = 7.1.4-SNAPSHOT
 
 # Please keep alphabetical
 cglib_nodep_version = 2.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,6 @@ group = com.twcable.grabbit
 version = 7.1.6
 
 # Please keep alphabetical
-apache_httpclient_version = 4.5.4
-apache_httpcore_version = 4.4.8
 cglib_nodep_version = 2.2.2
 commons_collections_version = 3.2.1
 commons_io_version = 1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,8 @@ group = com.twcable.grabbit
 version = 7.1.6
 
 # Please keep alphabetical
+apache_httpcore_version = 4.4.8
+apache_httpclient_version = 4.5.4
 cglib_nodep_version = 2.2.2
 commons_collections_version = 3.2.1
 commons_io_version = 1.4
@@ -41,6 +43,7 @@ servlet_api_version = 2.5
 slf4j_version = 1.7.6
 sling_api_version = 2.9.0
 sling_base_version = 2.2.2
+sling_commons_json_version = 2.0.6
 sling_commons_testing_version = 2.0.12
 sling_commons_version = 2.2.0
 sling_event_version = 3.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPe
 bundleInstallRoot = /apps/grabbit/install
 
 group = com.twcable.grabbit
-version = 7.1.5
+version = 7.1.6
 
 # Please keep alphabetical
 cglib_nodep_version = 2.2.2

--- a/gradle/bundle.gradle
+++ b/gradle/bundle.gradle
@@ -27,6 +27,9 @@ jar.manifest {
     attributes 'Bundle-Name': project.bundleName
     attributes 'Bundle-SymbolicName': project.symbolicName
     attributes 'Bundle-Description': project.bundleDescription
+    instruction 'Import-Package', 'org.apache.sling.commons.json; version="[2.0.4,3.0)"'
+    instruction 'Import-Package', 'org.apache.http; version="[4.0,5.0)"'
+    instruction 'Import-Package', 'org.apache.http.client; version="[4.0,5.0)"'
     instruction 'Import-Package', 'groovy.json; version="[2.3,3.0)"'
     instruction 'Import-Package', 'groovy.json.internal; version="[2.3,3.0)"'
     instruction 'Import-Package', 'org.springframework.batch.core.scope; version="[2.2,3.0)"'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,12 +23,6 @@ dependencies {
     }
     compile "org.apache.servicemix.bundles:org.apache.servicemix.bundles.okio:${okio_version}"
 
-    compile "org.apache.httpcomponents:httpcore-osgi:${apache_httpcore_version}"
-    compile "org.apache.httpcomponents:httpclient-osgi:${apache_httpclient_version}"
-
-    // JSON Commons Library
-    compile "org.apache.sling:org.apache.sling.commons.json:${sling_commons_json_version}"
-
     // Apache Sling libraries
     compile "org.apache.sling:org.apache.sling.api:${sling_api_version}"
     compile "org.apache.sling:org.apache.sling.jcr.base:${sling_base_version}"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,11 @@ dependencies {
     }
     compile "org.apache.servicemix.bundles:org.apache.servicemix.bundles.okio:${okio_version}"
 
+    compile "org.apache.httpcomponents:httpcore-osgi:${apache_httpcore_version}"
+    compile "org.apache.httpcomponents:httpclient-osgi:${apache_httpclient_version}"
+
+    // JSON Commons Library
+    compile "org.apache.sling:org.apache.sling.commons.json:${sling_commons_json_version}"
 
     // Apache Sling libraries
     compile "org.apache.sling:org.apache.sling.api:${sling_api_version}"

--- a/gradle/packageExclusions.gradle
+++ b/gradle/packageExclusions.gradle
@@ -39,15 +39,6 @@ configurations.cq_package {
     exclude group: 'org.apache.sling', module:'org.apache.sling.jcr.resource'
     exclude group: 'org.apache.sling', module: 'org.apache.sling.jcr.api'
 
-    // Exclude the Sling Commons JSON Library
-    exclude group: 'org.apache.sling', module: 'org.apache.sling.commons.json'
-
-    // HTTP Core OSGI
-    // 4.4.8
-    exclude group: 'org.apache.httpcomponents', module: 'httpcore-osgi'
-    // 4.5.4
-    exclude group: 'org.apache.httpcomponents', module: 'httpclient-osgi'
-
     // 6.x exclude bundles
     exclude group: 'com.google.guava', module: 'guava'
     exclude module: 'cq-workflow-console'

--- a/gradle/packageExclusions.gradle
+++ b/gradle/packageExclusions.gradle
@@ -39,6 +39,15 @@ configurations.cq_package {
     exclude group: 'org.apache.sling', module:'org.apache.sling.jcr.resource'
     exclude group: 'org.apache.sling', module: 'org.apache.sling.jcr.api'
 
+    // Exclude the Sling Commons JSON Library
+    exclude group: 'org.apache.sling', module: 'org.apache.sling.commons.json'
+
+    // HTTP Core OSGI
+    // 4.4.8
+    exclude group: 'org.apache.httpcomponents', module: 'httpcore-osgi'
+    // 4.5.4
+    exclude group: 'org.apache.httpcomponents', module: 'httpclient-osgi'
+
     // 6.x exclude bundles
     exclude group: 'com.google.guava', module: 'guava'
     exclude module: 'cq-workflow-console'

--- a/src/main/groovy/com/twcable/grabbit/GrabbitConfiguration.groovy
+++ b/src/main/groovy/com/twcable/grabbit/GrabbitConfiguration.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap
 import com.twcable.grabbit.util.CryptoUtil
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang3.builder.ToStringBuilder
 import org.yaml.snakeyaml.Yaml
 
 import javax.annotation.Nonnull
@@ -110,7 +111,7 @@ class GrabbitConfiguration {
 
         if (errorBuilder.hasErrors()) throw errorBuilder.build()
 
-        return new GrabbitConfiguration(
+        GrabbitConfiguration config = new GrabbitConfiguration(
             serverUsername,
             serverPassword,
             serverScheme,
@@ -119,6 +120,10 @@ class GrabbitConfiguration {
             deltaContent,
             pathConfigurations.asImmutable()
         )
+
+        log.info "# GrabbitConfiguration #\n${config}"
+
+        return config
     }
 
     private static final Pattern prePattern = Pattern.compile(/^(\/|\.\/|\\).*$/)
@@ -269,4 +274,8 @@ class GrabbitConfiguration {
         }
     }
 
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
 }

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
@@ -84,6 +84,11 @@ class CreateHttpConnectionTasklet implements Tasklet {
                 .url(getPostURLForRequest(jobParameters))
                 .addHeader('Authorization', Credentials.basic(username, password))
                 .build()
+//        final Request request = new RequestBuilder()
+//                .url(getURLForRequest(jobParameters))
+//                .addHeader('Authorization', Credentials.basic(username, password))
+//                .build()
+
 
         final OkHttpClient client = getNewHttpClient()
 

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
@@ -23,12 +23,6 @@ import groovy.util.logging.Slf4j
 import okhttp3.*
 import okhttp3.OkHttpClient.Builder as HttpClientBuilder
 import okhttp3.Request.Builder as RequestBuilder
-import org.apache.http.HttpEntity
-import org.apache.http.entity.AbstractHttpEntity
-import org.apache.http.entity.StringEntity
-import org.apache.sling.commons.json.JSONArray
-import org.apache.sling.commons.json.JSONException
-import org.apache.sling.commons.json.JSONObject
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.StepContribution
 import org.springframework.batch.core.scope.context.ChunkContext
@@ -84,11 +78,6 @@ class CreateHttpConnectionTasklet implements Tasklet {
                 .url(getPostURLForRequest(jobParameters))
                 .addHeader('Authorization', Credentials.basic(username, password))
                 .build()
-//        final Request request = new RequestBuilder()
-//                .url(getURLForRequest(jobParameters))
-//                .addHeader('Authorization', Credentials.basic(username, password))
-//                .build()
-
 
         final OkHttpClient client = getNewHttpClient()
 
@@ -117,20 +106,21 @@ class CreateHttpConnectionTasklet implements Tasklet {
                 excludePathsList.add(excludePath)
             }
 
-            JSONObject json = new JSONObject();
-            json.put("path", path);
-            json.put("after", after);
+            def jsonBuilder = new groovy.json.JsonBuilder()
 
-            JSONArray excludePathsArray = new JSONArray(excludePathsList);
+            def map = [:]
+            map["path"] = path
+            after["after"] = after
+            excludePaths["excludePaths"] = excludePathsList
 
-            json.put("excludePaths", excludePathsArray);
+            jsonBuilder {
+                map
+            }
 
-            RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), json.toString());
+            RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), jsonBuilder.toString());
             return requestBody;
         } catch (IOException ioe) {
             log.error(ioe.getMessage(), ioe);
-        } catch (JSONException e) {
-            log.error("Exception occurred forming JSON", e);
         }
         return null;
     }

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/http/CreateHttpConnectionTasklet.groovy
@@ -17,6 +17,7 @@ package com.twcable.grabbit.client.batch.steps.http
 
 import com.twcable.grabbit.client.batch.ClientBatchJob
 import com.twcable.grabbit.client.batch.ClientBatchJobContext
+import groovy.json.JsonBuilder
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -106,12 +107,17 @@ class CreateHttpConnectionTasklet implements Tasklet {
                 excludePathsList.add(excludePath)
             }
 
-            def jsonBuilder = new groovy.json.JsonBuilder()
+            def jsonBuilder = new JsonBuilder()
 
             def map = [:]
-            map["path"] = path
-            after["after"] = after
-            excludePaths["excludePaths"] = excludePathsList
+            map.path = path
+            map.after = after
+            map.excludePaths = excludePathsList
+
+//            Map map = new HashMap();
+//            map.put("path", path);
+//            map.put("after", after);
+//            map.put("excludePaths", excludePathsList);
 
             jsonBuilder {
                 map

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -37,11 +37,19 @@ class JcrNodesReader implements ItemReader<ProtoNode> {
 
     @Override
     NodeProtos.Node read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
-        ProtoNode nodeProto = ProtoNode.parseDelimitedFrom(theInputStream())
-        if (!nodeProto) {
-            log.info "Received all data from Server"
-            return null
+        ProtoNode nodeProto
+        try {
+            log.trace "JcrNodesReader.read() : START"
+            nodeProto = ProtoNode.parseDelimitedFrom(theInputStream())
+            if (!nodeProto) {
+                log.info "Received all data from Server"
+                return null
+            }
+        } catch (Exception e) {
+            log.error "Exception occurred parsing from the inputStream\n${e}"
         }
+        log.debug "read() : NodeProto: \n${nodeProto.name}"
+
         return nodeProto
     }
 

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -46,7 +46,7 @@ class JcrNodesReader implements ItemReader<ProtoNode> {
                 return null
             }
         } catch (Exception e) {
-            log.error "Exception occurred parsing from the inputStream\n${e}"
+            log.error "Exception occurred parsing from the inputStream\n${e}", e
         }
         log.debug "read() : NodeProto: \n${nodeProto.name}"
 

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -64,7 +64,8 @@ class JcrNodesWriter implements ItemWriter<ProtoNode>, ItemWriteListener {
         }
         try {
             theSession().save()
-        } catch(InvalidItemStateException|ConstraintViolationException|AccessDeniedException|ItemExistsException|ReferentialIntegrityException|VersionException|LockException|NoSuchNodeTypeException|RepositoryException e){
+//        } catch(InvalidItemStateException|ConstraintViolationException|AccessDeniedException|ItemExistsException|ReferentialIntegrityException|VersionException|LockException|NoSuchNodeTypeException|RepositoryException e){
+        } catch (Exception e) {
             log.error("Exception occurred when trying to save nodes on the client\n${e}")
         }
 

--- a/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/client/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -66,7 +66,7 @@ class JcrNodesWriter implements ItemWriter<ProtoNode>, ItemWriteListener {
             theSession().save()
 //        } catch(InvalidItemStateException|ConstraintViolationException|AccessDeniedException|ItemExistsException|ReferentialIntegrityException|VersionException|LockException|NoSuchNodeTypeException|RepositoryException e){
         } catch (Exception e) {
-            log.error("Exception occurred when trying to save nodes on the client\n${e}")
+            log.error("Exception occurred when trying to save nodes on the client\n${e}", e)
         }
 
         withStopWatch("Refreshing session: ${theSession()}") {

--- a/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.value.DateValue
 
 import static org.apache.jackrabbit.JcrConstants.JCR_CREATED
 import static org.apache.jackrabbit.JcrConstants.JCR_LASTMODIFIED
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYITEMNAME
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE
 import static org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants.AC_NODETYPE_NAMES
 import static org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants.NT_REP_ACL
@@ -120,6 +121,8 @@ class JCRNodeDecorator {
 
 
     String getPrimaryType() {
+        if (innerNode == null || innerNode.getProperty(JCR_PRIMARYTYPE) == null)
+            return ""
         innerNode.getProperty(JCR_PRIMARYTYPE).string
     }
 
@@ -202,6 +205,7 @@ class JCRNodeDecorator {
      */
     boolean isAuthorizablePart() {
         try {
+            if (getParent() == null) return false
             JCRNodeDecorator parent = new JCRNodeDecorator(getParent())
             while(!parent.isAuthorizableType()) {
                 parent = new JCRNodeDecorator(parent.getParent())

--- a/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/JCRNodeDecorator.groovy
@@ -35,7 +35,6 @@ import org.apache.jackrabbit.value.DateValue
 
 import static org.apache.jackrabbit.JcrConstants.JCR_CREATED
 import static org.apache.jackrabbit.JcrConstants.JCR_LASTMODIFIED
-import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYITEMNAME
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE
 import static org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants.AC_NODETYPE_NAMES
 import static org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants.NT_REP_ACL

--- a/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
@@ -77,13 +77,26 @@ class JcrPropertyDecorator {
         propertyBuilder.setName(name)
 
         if(type == BINARY) {
-            propertyBuilder.addValues(valueBuilder.setBytesValue(ByteString.readFrom(value.binary.stream)))
+            try {
+//                ByteString byteString = ByteString.readFrom(value.binary.stream, 268435456);
+                //ByteString byteString = ByteString.readFrom(value.binary.stream, 134217728);
+                ByteString byteString = ByteString.readFrom(value.binary.stream);
+                log.debug "name=${name}, type=BINARY, byteString.size=${byteString.size()}"
+                propertyBuilder.addValues(valueBuilder.setBytesValue(byteString))
+            } catch (Exception e) {
+                log.error "Exception occurred reading the binary value\n${e}"
+            }
         }
         else {
-            //Other property types can potentially have multiple values
-            final Value[] values = multiple ? values : [value] as Value[]
-            values.each { Value value ->
-                propertyBuilder.addValues(valueBuilder.setStringValue(value.string))
+            try {
+                //Other property types can potentially have multiple values
+                final Value[] values = multiple ? values : [value] as Value[]
+                values.each { Value value ->
+                    log.debug "name=${name}, type=OTHER, value.string.size=${value.string.size()}"
+                    propertyBuilder.addValues(valueBuilder.setStringValue(value.string))
+                }
+            } catch (Exception e) {
+                log.error "Exception occurred reading from other type\n${e}"
             }
         }
         propertyBuilder.setMultiple(multiple)

--- a/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
@@ -78,8 +78,6 @@ class JcrPropertyDecorator {
 
         if(type == BINARY) {
             try {
-//                ByteString byteString = ByteString.readFrom(value.binary.stream, 268435456);
-                //ByteString byteString = ByteString.readFrom(value.binary.stream, 134217728);
                 ByteString byteString = ByteString.readFrom(value.binary.stream);
                 log.debug "name=${name}, type=BINARY, byteString.size=${byteString.size()}"
                 propertyBuilder.addValues(valueBuilder.setBytesValue(byteString))

--- a/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/JcrPropertyDecorator.groovy
@@ -84,7 +84,7 @@ class JcrPropertyDecorator {
                 log.debug "name=${name}, type=BINARY, byteString.size=${byteString.size()}"
                 propertyBuilder.addValues(valueBuilder.setBytesValue(byteString))
             } catch (Exception e) {
-                log.error "Exception occurred reading the binary value\n${e}"
+                log.error "Exception occurred reading the binary value\n${e}", e
             }
         }
         else {
@@ -96,7 +96,7 @@ class JcrPropertyDecorator {
                     propertyBuilder.addValues(valueBuilder.setStringValue(value.string))
                 }
             } catch (Exception e) {
-                log.error "Exception occurred reading from other type\n${e}"
+                log.error "Exception occurred reading from other type\n${e}", e
             }
         }
         propertyBuilder.setMultiple(multiple)

--- a/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
@@ -23,10 +23,14 @@ import groovy.util.logging.Slf4j
 import javax.annotation.Nonnull
 import javax.jcr.Node as JCRNode
 import javax.jcr.PropertyType
+import javax.jcr.RepositoryException
 import javax.jcr.Value
 import javax.jcr.ValueFormatException
 import org.apache.jackrabbit.value.ValueFactoryImpl
 
+import javax.jcr.lock.LockException
+import javax.jcr.nodetype.ConstraintViolationException
+import javax.jcr.version.VersionException
 
 import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE
@@ -60,6 +64,9 @@ class ProtoPropertyDecorator {
             else {
                 node.setProperty(this.name, getPropertyValue(), this.type)
             }
+        }
+        catch (VersionException|LockException|ConstraintViolationException|RepositoryException e) {
+            log.error "Exception occurred trying to save properties on a node\n${e}"
         }
         catch (ValueFormatException ex) {
             //We do this for the case were Grabbit attempts to write a property of a type different from the type already written i.e String vs String[]

--- a/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
@@ -84,7 +84,7 @@ class ProtoPropertyDecorator {
                 log.warn "WARNING!  Property ${name} will not be written to ${node.name}!  There was a problem when writing value type ${PropertyType.nameFromValue(type)}${multiple ? '[]' : ''} to existing node with same type, due to a ValueFormatException, and we were unable to recover"
             }
         } catch (Exception e) {
-            log.error "Exception occurred trying to save properties on a node\n${e}"
+            log.error "Exception occurred trying to save properties on a node\n${e}", e
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
@@ -65,9 +65,9 @@ class ProtoPropertyDecorator {
                 node.setProperty(this.name, getPropertyValue(), this.type)
             }
         }
-        catch (VersionException|LockException|ConstraintViolationException|RepositoryException e) {
-            log.error "Exception occurred trying to save properties on a node\n${e}"
-        }
+//        catch (VersionException|LockException|ConstraintViolationException|RepositoryException e) {
+//            log.error "Exception occurred trying to save properties on a node\n${e}"
+//        }
         catch (ValueFormatException ex) {
             //We do this for the case were Grabbit attempts to write a property of a type different from the type already written i.e String vs String[]
             //Get the problem property already set on the node
@@ -75,15 +75,16 @@ class ProtoPropertyDecorator {
 
             log.debug "Failure initially setting property ${name} with type: ${PropertyType.nameFromValue(type)}${multiple ? '[]' : ''} to existing property with type: ${PropertyType.nameFromValue(existingProperty.type)}${existingProperty.multiple ? '[]' : ''}.  Trying to resolve..."
             //If the type is different than what we expect to write, or the cardinality is different; remove what is already written, and retry
-            if(existingProperty.type != this.type || existingProperty.multiple ^ this.multiple) {
+            if (existingProperty.type != this.type || existingProperty.multiple ^ this.multiple) {
                 existingProperty.remove()
                 node.session.save()
                 this.writeToNode(node)
                 log.debug "Resolve successful..."
-            }
-            else {
+            } else {
                 log.warn "WARNING!  Property ${name} will not be written to ${node.name}!  There was a problem when writing value type ${PropertyType.nameFromValue(type)}${multiple ? '[]' : ''} to existing node with same type, due to a ValueFormatException, and we were unable to recover"
             }
+        } catch (Exception e) {
+            log.error "Exception occurred trying to save properties on a node\n${e}"
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/jcr/ProtoPropertyDecorator.groovy
@@ -65,9 +65,6 @@ class ProtoPropertyDecorator {
                 node.setProperty(this.name, getPropertyValue(), this.type)
             }
         }
-//        catch (VersionException|LockException|ConstraintViolationException|RepositoryException e) {
-//            log.error "Exception occurred trying to save properties on a node\n${e}"
-//        }
         catch (ValueFormatException ex) {
             //We do this for the case were Grabbit attempts to write a property of a type different from the type already written i.e String vs String[]
             //Get the problem property already set on the node

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
@@ -70,7 +70,14 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, ProtoNode> {
         } else {
             // Build parent node
             log.debug "Build parent node..."
-            return decoratedNode.toProtoNode()
+            ProtoNode protoNode
+            try {
+                protoNode = decoratedNode.toProtoNode()
+                log.info "after building parent node. Have the protoNode ready"
+            } catch (Exception e) {
+                log.error "Exception occurred saving to protoNode\n${e}"
+            }
+            return protoNode
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
@@ -53,6 +53,7 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, ProtoNode> {
             final Date afterDate = DateUtil.getDateFromISOString(contentAfterDate)
             log.debug "ContentAfterDate received : ${afterDate}. Will ignore content created or modified before the afterDate"
             final date = decoratedNode.getModifiedOrCreatedDate()
+            log.debug "jcrNode=${jcrNode.getPath()}\nafterDate=${afterDate}\ncreated or modified date=${date}"
             if (date && date.before(afterDate)) { //if there are no date properties, we treat nodes as new
                 log.debug "Not sending any data older than ${afterDate}"
                 return null
@@ -61,9 +62,14 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, ProtoNode> {
 
         // Skip some nodes because they have already been processed by their parent
         if(decoratedNode.isMandatoryNode() || decoratedNode.isAuthorizablePart() || decoratedNode.isACPart()) {
+            log.debug "Skip some nodes because they have already been processed by their parent\ndecoratedNode" +
+                    ".isMandatoryNode=${decoratedNode.isMandatoryNode()}\ndecoratedNode.isAuthorizablePart()" +
+                    "=${decoratedNode.isAuthorizablePart()}\ndecoratedNode.isACPart()=${decoratedNode.isACPart()}"
+
             return null
         } else {
             // Build parent node
+            log.debug "Build parent node..."
             return decoratedNode.toProtoNode()
         }
     }

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessor.groovy
@@ -75,7 +75,7 @@ class JcrNodesProcessor implements ItemProcessor<JcrNode, ProtoNode> {
                 protoNode = decoratedNode.toProtoNode()
                 log.info "after building parent node. Have the protoNode ready"
             } catch (Exception e) {
-                log.error "Exception occurred saving to protoNode\n${e}"
+                log.error "Exception occurred saving to protoNode\n${e}", e
             }
             return protoNode
         }

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -18,6 +18,7 @@ package com.twcable.grabbit.server.batch.steps.jcrnodes
 
 import com.twcable.grabbit.server.batch.ServerBatchJobContext
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.NonTransientResourceException
 import org.springframework.batch.item.ParseException
@@ -29,6 +30,7 @@ import javax.jcr.Node as JcrNode
  * A Custom ItemReader that provides the "next" Node from the {@link ServerBatchJobContext#nodeIterator}.
  * Returns null to indicate that all Items have been read.
  */
+@Slf4j
 @CompileStatic
 @SuppressWarnings("GrMethodMayBeStatic")
 class JcrNodesReader implements ItemReader<JcrNode> {
@@ -37,11 +39,14 @@ class JcrNodesReader implements ItemReader<JcrNode> {
     JcrNode read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
         Iterator<JcrNode> nodeIterator = theNodeIterator()
         if (nodeIterator == null) throw new IllegalStateException("nodeIterator must be set.")
-        if (nodeIterator.hasNext()) {
-            nodeIterator.next()
-        }
-        else {
-            null
+        try {
+            if (nodeIterator.hasNext()) {
+                nodeIterator.next()
+            } else {
+                null
+            }
+        } catch (Exception e) {
+            log.error "Exception occurred reading nodes: ${e}"
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -41,7 +41,9 @@ class JcrNodesReader implements ItemReader<JcrNode> {
         if (nodeIterator == null) throw new IllegalStateException("nodeIterator must be set.")
         try {
             if (nodeIterator.hasNext()) {
-                nodeIterator.next()
+                JcrNode jcrNode = nodeIterator.next()
+                log.debug "jcrNode.path=${jcrNode.getPath()}"
+                return jcrNode
             } else {
                 null
             }

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -42,8 +42,10 @@ class JcrNodesReader implements ItemReader<JcrNode> {
         try {
             if (nodeIterator.hasNext()) {
                 JcrNode jcrNode = nodeIterator.next()
-                log.debug "jcrNode.path=${jcrNode.getPath()}"
-                return jcrNode
+                if (jcrNode != null) {
+                    log.debug "jcrNode.path={}", jcrNode.getPath()
+                    return jcrNode
+                }
             } else {
                 null
             }

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesReader.groovy
@@ -48,7 +48,7 @@ class JcrNodesReader implements ItemReader<JcrNode> {
                 null
             }
         } catch (Exception e) {
-            log.error "Exception occurred reading nodes: ${e}"
+            log.error "Exception occurred reading nodes: ${e}", e
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -55,11 +55,11 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
                     node.writeDelimitedTo(servletOutputStream)
                     log.info("write : after sending nodeProto to outputstream")
                 } catch (Exception e2) {
-                    log.error "Exception occurred writing node delimited to outputstream. e=${e2}"
+                    log.error "Exception occurred writing node delimited to outputstream. e=${e2}", e2
                 }
             }
         } catch (Exception e) {
-            log.error "Exception occurred writing to the outputstream: ${e}"
+            log.error "Exception occurred writing to the outputstream: ${e}", e
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -42,9 +42,21 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
         if (servletOutputStream == null) throw new IllegalStateException("servletOutputStream must be set.")
 
         try {
+            //log.info "\n\n### NodeProtos ###\n\n${StringUtils.join(nodeProtos.toString(), "\n")}"
             nodeProtos.each { NodeProtos.Node node ->
-                log.debug "Sending NodeProto : ${node}"
-                node.writeDelimitedTo(servletOutputStream)
+                log.debug "Sending NodeProto : ${node.getName()}"
+                if (log.isDebugEnabled()) {
+                    log.debug "NodeProto.serializedSize=${node.getSerializedSize()}"
+                }
+                if (log.isTraceEnabled()) {
+                    log.trace "Sending NodeProto : ${node}"
+                }
+                try {
+                    node.writeDelimitedTo(servletOutputStream)
+                    log.info("write : after sending nodeProto to outputstream")
+                } catch (Exception e2) {
+                    log.error "Exception occurred writing node delimited to outputstream. e=${e2}"
+                }
             }
         } catch (Exception e) {
             log.error "Exception occurred writing to the outputstream: ${e}"
@@ -59,6 +71,7 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
 
     @Override
     void afterWrite(List items) {
+        log.info "afterWrite() : about to flush"
         theServletOutputStream().flush()
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -20,6 +20,7 @@ import com.twcable.grabbit.proto.NodeProtos
 import com.twcable.grabbit.server.batch.ServerBatchJobContext
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang3.StringUtils
 import org.springframework.batch.core.ItemWriteListener
 import org.springframework.batch.item.ItemWriter
 
@@ -61,6 +62,7 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
     @Override
     void onWriteError(Exception exception, List items) {
         log.error "Exception occurred while writing the current chunk", exception
+        log.warn "Items where the error occurred are: \n" + StringUtils.join(items, "\n======================\n");
     }
 
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -41,9 +41,13 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
         ServletOutputStream servletOutputStream = theServletOutputStream()
         if (servletOutputStream == null) throw new IllegalStateException("servletOutputStream must be set.")
 
-        nodeProtos.each { NodeProtos.Node node ->
-            log.debug "Sending NodeProto : ${node}"
-            node.writeDelimitedTo(servletOutputStream)
+        try {
+            nodeProtos.each { NodeProtos.Node node ->
+                log.debug "Sending NodeProto : ${node}"
+                node.writeDelimitedTo(servletOutputStream)
+            }
+        } catch (Exception e) {
+            log.error "Exception occurred writing to the outputstream: ${e}"
         }
     }
 

--- a/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesWriter.groovy
@@ -42,7 +42,6 @@ class JcrNodesWriter implements ItemWriter<NodeProtos.Node>, ItemWriteListener {
         if (servletOutputStream == null) throw new IllegalStateException("servletOutputStream must be set.")
 
         try {
-            //log.info "\n\n### NodeProtos ###\n\n${StringUtils.join(nodeProtos.toString(), "\n")}"
             nodeProtos.each { NodeProtos.Node node ->
                 log.debug "Sending NodeProto : ${node.getName()}"
                 if (log.isDebugEnabled()) {

--- a/src/main/groovy/com/twcable/grabbit/server/services/ExcludePathNodeIterator.groovy
+++ b/src/main/groovy/com/twcable/grabbit/server/services/ExcludePathNodeIterator.groovy
@@ -17,6 +17,8 @@
 package com.twcable.grabbit.server.services
 
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
 import javax.jcr.Node as JcrNode
 
 /**
@@ -24,6 +26,7 @@ import javax.jcr.Node as JcrNode
  * Accounts for cases where certain paths(i.e nodes) needs to be excluded.
  */
 @CompileStatic
+@Slf4j
 final class ExcludePathNodeIterator implements Iterator<JcrNode> {
 
     private Iterator<JcrNode> nodeIterator
@@ -53,6 +56,9 @@ final class ExcludePathNodeIterator implements Iterator<JcrNode> {
     }
 
     private boolean isPathInExcludedList(String path) {
-        return excludePathList.any { path.startsWith(it) }
+        boolean result = excludePathList.any { path.startsWith(it + "/") || path.equals(it) }
+
+        log.debug "isPathInExcludedList() : path={}, result={}", path, result
+        return result
     }
 }

--- a/src/main/groovy/com/twcable/grabbit/server/services/impl/TreeTraverser.java
+++ b/src/main/groovy/com/twcable/grabbit/server/services/impl/TreeTraverser.java
@@ -1,0 +1,344 @@
+package com.twcable.grabbit.server.services.impl;
+
+
+import static org.apache.jackrabbit.commons.iterator.LazyIteratorChain.chain;
+
+import org.apache.jackrabbit.commons.iterator.FilterIterator;
+import org.apache.jackrabbit.commons.predicate.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * <p>
+ * Utility class for traversing the {@link Item}s of a JCR hierarchy rooted at a
+ * specific {@link Node}.
+ * </p>
+ *
+ * <p>
+ * This class provides an {@link Iterator} of JCR items either through its
+ * implementation of {@link Iterable} or through various static factory methods.
+ * The iterators return its elements in pre-order. That is, each node occurs
+ * before its child nodes are traversed. The order in which child nodes are
+ * traversed is determined by the underlying JCR implementation. Generally the
+ * order is not specified unless a {@link Node} has orderable child nodes.
+ * </p>
+ *
+ * <p>
+ * Whether a specific node is included is determined by an
+ * InclusionPolicy. Error occurring while traversing are delegated to
+ * an ErrorHandler.
+ * </p>
+ */
+public final class TreeTraverser implements Iterable<Node> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TreeTraverser.class);
+    private final Node root;
+    private final TreeTraverser.ErrorHandler errorHandler;
+    private final TreeTraverser.InclusionPolicy<? super Node> inclusionPolicy;
+
+    /**
+     * Create a new instance of a TreeTraverser rooted at <code>node</code>.
+     *
+     * @param root The root node of the sub-tree to traverse
+     * @param errorHandler Handler for errors while traversing
+     * @param inclusionPolicy Inclusion policy to determine which nodes to
+     *            include
+     */
+    public TreeTraverser(Node root, TreeTraverser.ErrorHandler errorHandler, TreeTraverser.InclusionPolicy<? super Node> inclusionPolicy) {
+        super();
+        this.root = root;
+        this.errorHandler = errorHandler == null? TreeTraverser.ErrorHandler.ALL : errorHandler;
+        this.inclusionPolicy = inclusionPolicy;
+    }
+
+    /**
+     * Create a new instance of a TreeTraverser rooted at <code>node</code>.
+     *
+     * @param root The root node of the sub-tree to traverse
+     */
+    public TreeTraverser(Node root) {
+        this(root, TreeTraverser.ErrorHandler.ALL, TreeTraverser.InclusionPolicy.ALL);
+    }
+
+    /**
+     * Error handler for handling {@link RepositoryException}s occurring on
+     * traversal. The predefined {@link #IGNORE} error handler can be used to
+     * ignore all exceptions.
+     */
+    public interface ErrorHandler {
+
+        /**
+         * Predefined error handler which ignores all exceptions.
+         */
+        public static TreeTraverser.ErrorHandler IGNORE = new TreeTraverser.ErrorHandler() {
+            public void call(Item item, RepositoryException exception) { /* ignore */ }
+        };
+
+        /**
+         * Predefined error handler which logs all exceptions.
+         */
+        public static TreeTraverser.ErrorHandler ALL = new TreeTraverser.ErrorHandler() {
+            public void call(Item item, RepositoryException exception) { LOG.error("Exception occurred traversing the tree", exception); }
+        };
+
+        /**
+         * This call back method is called whenever an error occurs while
+         * traversing.
+         *
+         * @param item The item which was the target of an operation which
+         *            failed and caused the exception.
+         * @param exception The exception which occurred.
+         */
+        void call(Item item, RepositoryException exception);
+    }
+
+    /**
+     * Inclusion policy to determine which items to include when traversing.
+     * There a two predefined inclusion policies:
+     * <ul>
+     * <li>{@link #ALL} includes all items.</li>
+     * <li>{@link #LEAVES} includes only leave nodes. A leaf node is a node
+     * which does not have child nodes.</li>
+     * </ul>
+     */
+    public interface InclusionPolicy<T extends Item> {
+
+        /**
+         * This inclusions policy includes all items.
+         */
+        public static TreeTraverser.InclusionPolicy<Item> ALL = new TreeTraverser.InclusionPolicy<Item>() {
+            public boolean include(Item item) {
+                return true;
+            }
+        };
+
+        /**
+         * This inclusion policy includes leave nodes only. A leaf
+         * node is a node which does not have child nodes.
+         */
+        public static TreeTraverser.InclusionPolicy<Node> LEAVES = new TreeTraverser.InclusionPolicy<Node>() {
+            public boolean include(Node node) {
+                try {
+                    return !node.hasNodes();
+                }
+                catch (RepositoryException e) {
+                    return false;
+                }
+            }
+        };
+
+        /**
+         * Call back method to determine whether to include a given item.
+         *
+         * @param item The item under consideration
+         * @return <code>true</code> when <code>item</code> should be included.
+         *         <code>false</code> otherwise.
+         */
+        boolean include(T item);
+    }
+
+    /**
+     * Create an iterator for the nodes of the sub-tree rooted at
+     * <code>root</code>.
+     *
+     * @param root root node of the sub-tree to traverse
+     * @param errorHandler handler for exceptions occurring on traversal
+     * @param inclusionPolicy inclusion policy to determine which nodes to
+     *            include
+     * @return iterator of {@link Node}
+     */
+    public static Iterator<Node> nodeIterator(Node root, TreeTraverser.ErrorHandler errorHandler,
+                                              TreeTraverser.InclusionPolicy<? super Node> inclusionPolicy) {
+
+        return new TreeTraverser(root, errorHandler, inclusionPolicy).iterator();
+    }
+
+    /**
+     * Create an iterator for the nodes of the sub-tree rooted at
+     * <code>root</code>. Exceptions occurring on traversal are ignored.
+     *
+     * @param root root node of the sub-tree to traverse
+     * @return iterator of {@link Node}
+     */
+    public static Iterator<Node> nodeIterator(Node root) {
+        return nodeIterator(root, TreeTraverser.ErrorHandler.ALL, TreeTraverser.InclusionPolicy.ALL);
+    }
+
+    /**
+     * Create an iterator of the properties for a given iterator of nodes. The
+     * order of the returned properties is only specified so far that if node
+     * <code>n1</code> occurs before node <code>n2</code> in the iterator of
+     * nodes, then any property of <code>n1</code> will occur before any
+     * property of <code>n2</code>.
+     *
+     * @param nodes nodes whose properties to chain
+     * @param errorHandler handler for exceptions occurring on traversal
+     * @param inclusionPolicy inclusion policy to determine properties items to include
+     *
+     * @return iterator of {@link Property}
+     */
+    public static Iterator<Property> propertyIterator(Iterator<Node> nodes, TreeTraverser.ErrorHandler errorHandler,
+                                                      TreeTraverser.InclusionPolicy<? super Property> inclusionPolicy) {
+
+        return filter(chain(propertyIterators(nodes, errorHandler)), inclusionPolicy);
+    }
+
+
+    /**
+     * Create an iterator of the properties for a given iterator of nodes. The
+     * order of the returned properties is only specified so far that if node
+     * <code>n1</code> occurs before node <code>n2</code> in the iterator of
+     * nodes, then any property of <code>n1</code> will occur before any
+     * property of <code>n2</code>. Exceptions occurring on traversal are
+     * ignored.
+     *
+     * @param nodes nodes whose properties to chain
+     * @return iterator of {@link Property}
+     */
+    public static Iterator<Property> propertyIterator(Iterator<Node> nodes) {
+        return propertyIterator(nodes, TreeTraverser.ErrorHandler.ALL, TreeTraverser.InclusionPolicy.ALL);
+    }
+
+    /**
+     * Create an iterator of the properties of all nodes of the sub-tree rooted
+     * at <code>root</code>.
+     *
+     * @param root root node of the sub-tree to traverse
+     * @param errorHandler handler for exceptions occurring on traversal
+     * @param inclusionPolicy inclusion policy to determine which items to
+     *            include
+     * @return iterator of {@link Property}
+     */
+    public static Iterator<Property> propertyIterator(Node root, TreeTraverser.ErrorHandler errorHandler,
+                                                      TreeTraverser.InclusionPolicy<Item> inclusionPolicy) {
+
+        return propertyIterator(nodeIterator(root, errorHandler, inclusionPolicy), errorHandler,
+                inclusionPolicy);
+    }
+
+    /**
+     * Create an iterator of the properties of all nodes of the sub-tree rooted
+     * at <code>root</code>. Exceptions occurring on traversal are ignored.
+     *
+     * @param root root node of the sub-tree to traverse
+     * @return iterator of {@link Property}
+     */
+    public static Iterator<Property> propertyIterator(Node root) {
+        return propertyIterator(root, TreeTraverser.ErrorHandler.ALL, TreeTraverser.InclusionPolicy.ALL);
+    }
+
+    /**
+     * Returns an iterator of {@link Node} for this instance.
+     *
+     * @see TreeTraverser#TreeTraverser(Node, TreeTraverser.ErrorHandler, TreeTraverser.InclusionPolicy)
+     * @see java.lang.Iterable#iterator()
+     */
+    public Iterator<Node> iterator() {
+        return iterator(root);
+    }
+
+    // -----------------------------------------------------< internal >---
+
+    /**
+     * Returns an iterator of the nodes of the sub-tree rooted at
+     * <code>node</code>.
+     */
+    @SuppressWarnings("unchecked")
+    private Iterator<Node> iterator(Node node) {
+        if (inclusionPolicy.include(node)) {
+            return chain(singleton(node), chain(childIterators(node)));
+        }
+        else {
+            return chain(childIterators(node));
+        }
+    }
+
+    /**
+     * Returns an iterator of iterators of the child nodes of <code>node</code>.
+     */
+    private Iterator<Iterator<Node>> childIterators(Node node) {
+        try {
+            final NodeIterator childNodes = node.getNodes();
+            return new Iterator<Iterator<Node>>() {
+                public boolean hasNext() {
+                    return childNodes.hasNext();
+                }
+                public Iterator<Node> next() {
+                    return iterator(childNodes.nextNode());
+                }
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        } catch (RepositoryException e) {
+            errorHandler.call(node, e);
+            return empty();
+        }
+    }
+
+    /**
+     * Returns an iterator of all properties of all <code>nodes</code>. For node
+     * <code>n1</code> occurring before node <code>n2</code> in
+     * <code>nodes</code>, any property of <code>n1</code> will occur before any
+     * property of <code>n2</code> in the iterator.
+     */
+    private static Iterator<Iterator<Property>> propertyIterators(final Iterator<Node> nodes,
+                                                                  final TreeTraverser.ErrorHandler errorHandler) {
+
+        return new Iterator<Iterator<Property>>() {
+            public boolean hasNext() {
+                return nodes.hasNext();
+            }
+
+            @SuppressWarnings("unchecked")
+            public Iterator<Property> next() {
+                Node n = nodes.next();
+                try {
+                    return n.getProperties();
+                } catch (RepositoryException e) {
+                    errorHandler.call(n, e);
+                    return empty();
+                }
+            }
+
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    // -----------------------------------------------------< utility >---
+
+    private static <T> Iterator<T> empty() {
+        return Collections.<T>emptySet().iterator();
+    }
+
+    private <T> Iterator<T> singleton(T value) {
+        return Collections.singleton(value).iterator();
+    }
+
+    /**
+     * Filtering items not matching the <code>inclusionPolicy</code> from
+     * <code>iterator</code>.
+     */
+    private static <T extends Item> Iterator<T> filter(final Iterator<T> iterator,
+                                                       final TreeTraverser.InclusionPolicy<? super T> inclusionPolicy) {
+
+        return new FilterIterator<T>(iterator, new Predicate() {
+            @SuppressWarnings("unchecked")
+            public boolean evaluate(Object object) {
+                return inclusionPolicy.include((T) object);
+            }
+        });
+    }
+
+}

--- a/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
@@ -23,6 +23,9 @@ import spock.lang.Subject
 
 import javax.servlet.ServletOutputStream
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
 @Subject(GrabbitContentPullServlet)
 class GrabbitContentPullServletSpec extends Specification {
 

--- a/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
@@ -18,6 +18,7 @@ package com.twcable.grabbit.server
 import com.twcable.grabbit.server.services.ServerService
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
+import org.junit.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -26,6 +27,7 @@ import javax.servlet.ServletOutputStream
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import static javax.servlet.http.HttpServletResponse.SC_OK
 
+@Ignore
 @Subject(GrabbitContentPullServlet)
 class GrabbitContentPullServletSpec extends Specification {
 

--- a/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
@@ -18,6 +18,7 @@ package com.twcable.grabbit.server
 import com.twcable.grabbit.server.services.ServerService
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
+import org.junit.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
 

--- a/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/GrabbitContentPullServletSpec.groovy
@@ -18,14 +18,10 @@ package com.twcable.grabbit.server
 import com.twcable.grabbit.server.services.ServerService
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
-import org.junit.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
 
 import javax.servlet.ServletOutputStream
-
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
-import static javax.servlet.http.HttpServletResponse.SC_OK
 
 @Subject(GrabbitContentPullServlet)
 class GrabbitContentPullServletSpec extends Specification {

--- a/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
@@ -359,7 +359,6 @@ class JcrNodesProcessorSpec extends Specification {
         propList = aJcrNode.properties.toList().findAll {it.name != JcrConstants.JCR_PRIMARYTYPE}.collectEntries { [(it.name): new DateTime(it.value.date.time.time)]}
     }
 
-    @Ignore('TODO: Skip for now in order to build the project')
     def "A mandatory node is not processed"() {
         given:
         final JcrNode node = Mock(JcrNode) {
@@ -378,7 +377,6 @@ class JcrNodesProcessorSpec extends Specification {
         result == null
     }
 
-    @Ignore('TODO: Skip for now in order to build the project')
     def "An authorizable part is not processed"() {
         given:
         final JcrNode node = Mock(JcrNode) {

--- a/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
@@ -20,7 +20,6 @@ import com.twcable.grabbit.proto.NodeProtos.Node as ProtoNode
 import com.twcable.grabbit.proto.NodeProtos.Property as ProtoProperty
 import com.twcable.jackalope.NodeBuilder as FakeNodeBuilder
 import com.twcable.jackalope.impl.jcr.ValueImpl
-import spock.lang.Ignore
 
 import javax.jcr.ItemNotFoundException
 import javax.jcr.Node as JcrNode

--- a/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
+++ b/src/test/groovy/com/twcable/grabbit/server/batch/steps/jcrnodes/JcrNodesProcessorSpec.groovy
@@ -20,6 +20,8 @@ import com.twcable.grabbit.proto.NodeProtos.Node as ProtoNode
 import com.twcable.grabbit.proto.NodeProtos.Property as ProtoProperty
 import com.twcable.jackalope.NodeBuilder as FakeNodeBuilder
 import com.twcable.jackalope.impl.jcr.ValueImpl
+import spock.lang.Ignore
+
 import javax.jcr.ItemNotFoundException
 import javax.jcr.Node as JcrNode
 import javax.jcr.NodeIterator
@@ -357,6 +359,7 @@ class JcrNodesProcessorSpec extends Specification {
         propList = aJcrNode.properties.toList().findAll {it.name != JcrConstants.JCR_PRIMARYTYPE}.collectEntries { [(it.name): new DateTime(it.value.date.time.time)]}
     }
 
+    @Ignore('TODO: Skip for now in order to build the project')
     def "A mandatory node is not processed"() {
         given:
         final JcrNode node = Mock(JcrNode) {
@@ -375,6 +378,7 @@ class JcrNodesProcessorSpec extends Specification {
         result == null
     }
 
+    @Ignore('TODO: Skip for now in order to build the project')
     def "An authorizable part is not processed"() {
         given:
         final JcrNode node = Mock(JcrNode) {


### PR DESCRIPTION
* Changes that improve resiliency like catching some of the errors encountered to keep the jobs running. It would be great if that was perhaps put into a configuration whether to fail-fast or just log those errors as warnings and go on. I don't know enough about the best approach for something like that would be.
* Converted the servlet on the source being pulled from to handle post requests instead of get. That way the requests won't be limited by the GET URL length. This can be useful if there are a ton of exclusions as we've encountered.
* Also I made a change to how the exclusion filters are matching the paths. Currently the paths will be searched to find the exclusion string in any part of the path, instead I've made it so that the string is matched against just the startsWith instead. Not sure if that's how it's intended to be used, but perhaps that can also be configured somehow in the exclusion filter section itself.
* Added more debug logging