### PR TITLE
Fix for issue 153 sun.misc Import-Package

### DIFF
--- a/docs/AEMSupport.adoc
+++ b/docs/AEMSupport.adoc
@@ -1,7 +1,6 @@
 == What you need to run Grabbit.
 
 * Supported AEM/CQ version per below
-* One-time installation of a system Fragment Bundle is needed. It can be found link:https://bintray.com/artifact/download/twcable/aem/dependencies/Sun-Misc-Fragment-Bundle-1.0.0.zip[here]
 * If running AEM 6.2+ with the AEM Deserialization Firewall enabled, link:https://bintray.com/twcable/aem/download_file?file_path=dependencies%2FGrabbit-Deserialization-Firewall-Configuration-1.0.zip[this package] is required in order
 for Grabbit to work. If running the deserialization firewall with custom blacklist/whitelist rules, check out the package description to gather which additional paths will need to be considered.
 * In Addition to the AEM Deserialization Firewall package, you would need to install link:https://bintray.com/artifact/download/twcable/aem/dependencies/Grabbit-Apache-Sling-Login-Whitelist-1.0.zip[this] to have the grabbit bundle be whitelisted with Apache Sling Login Admin.

--- a/gradle/bundle.gradle
+++ b/gradle/bundle.gradle
@@ -51,7 +51,7 @@ jar.manifest {
     instruction 'Import-Package', 'org.springframework.aop.scope; version="[3.1,4.0)"'
     instruction 'Import-Package', 'org.springframework.scheduling.concurrent; version="[3.1,4.0)"'
     instruction 'Import-Package', "org.aopalliance.aop;version=1.0.0"
-    instruction 'Import-Package', "sun.misc"
+    instruction 'Import-Package', "sun.misc;resolution:=optional"
     instruction 'Import-Package', '*'
 
     // export everything to OSGi except *.impl packages


### PR DESCRIPTION
Changed the sun.misc package as an optional OSGi resolution.  This will remove the dependency on installing system Fragment Bundle for sun.misc and improve the installation process